### PR TITLE
i2447: Update to use new vault

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,4 @@ Imports:
     jsonlite,
     montagu (>= 0.2.0),
     rdrop2,
-    vaultr
+    vaultr (>= 0.2.0)

--- a/R/dropbox.R
+++ b/R/dropbox.R
@@ -72,7 +72,7 @@ drop_download2 <- function(path, dest = tempfile()) {
 
 dropbox_login <- function(renew = FALSE) {
   vault_path <- "/secret/import/dropbox-token"
-  vault <- vaultr::vault_client()
+  vault <- vaultr::vault_client(login = "github")
 
   token <- vault$read(vault_path)
   if (renew || is.null(token)) {

--- a/R/login.R
+++ b/R/login.R
@@ -1,5 +1,5 @@
 montagu_login <- function(name) {
-  vault <- vaultr::vault_client()
+  vault <- vaultr::vault_client(login = "github")
   if (name == "uat") {
     host <- "support.montagu.dide.ic.ac.uk"
     port <- 10443


### PR DESCRIPTION
There are breaking changes in the next version of vaultr - this updates the package to use them.  There are a group of these PRs and they should be merged together, followed by updating the drat in order to minimise disruption.